### PR TITLE
Update app.py

### DIFF
--- a/appr/api/app.py
+++ b/appr/api/app.py
@@ -27,8 +27,8 @@ def create_app():
         app.config.from_object(ProductionConfig)
     from appr.api.info import info_app
     from appr.api.registry import registry_app
-    app.register_blueprint(info_app, url_prefix='/cnr')
-    app.register_blueprint(registry_app, url_prefix='/cnr')
+    app.register_blueprint(info_app, url_prefix='/')
+    app.register_blueprint(registry_app, url_prefix='/')
     app.logger.info("Start service")
     return app
 


### PR DESCRIPTION
Red Hat Quay Registry 3.8 does not support url with /cnr prefix, until version 3.7 this was supported.

I propose replacing "/cnr" with "/" 

OR

Alternatively allow for passing the url_prefix as a parameter I am not an python expert would need some help around this.

Please let me know asap.

Regards,

Ramachandran Srinivasan