### PR TITLE
Update app.py url_prefix is not valid anymore in 3.8 red hat quay

### DIFF
--- a/appr/api/app.py
+++ b/appr/api/app.py
@@ -27,8 +27,8 @@ def create_app():
         app.config.from_object(ProductionConfig)
     from appr.api.info import info_app
     from appr.api.registry import registry_app
-    app.register_blueprint(info_app, url_prefix='/cnr')
-    app.register_blueprint(registry_app, url_prefix='/cnr')
+    app.register_blueprint(info_app, url_prefix='/')
+    app.register_blueprint(registry_app, url_prefix='/')
     app.logger.info("Start service")
     return app
 


### PR DESCRIPTION
Update app.py url_prefix is not valid anymore in 3.8 red hat quay so push '/' instead of '/cnr'